### PR TITLE
fix: use post-entrypoint script to run cleanup tasks

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,6 +1,6 @@
 name: QA
 
-on: push
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run_qa:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,6 +1,6 @@
 name: QA
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 jobs:
   run_qa:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ LABEL version="1.1.0" \
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+COPY cleanup.sh /cleanup.sh
+RUN chmod +x /cleanup.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ branding:
 runs:
   using: docker
   image: Dockerfile
+  entrypoint: "/entrypoint.sh"
+  post-entrypoint: "/cleanup.sh"
 inputs:
   args:
     description: Additional arguments to the sonar-scanner

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+_tmp_file=$(ls "${INPUT_PROJECTBASEDIR}/" | head -1)
+PERM=$(stat -c "%u:%g" "${INPUT_PROJECTBASEDIR}/$_tmp_file")
+
+chown -R $PERM "${INPUT_PROJECTBASEDIR}/"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,3 @@ unset JAVA_HOME
 
 sonar-scanner -Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR} ${INPUT_ARGS}
 
-_tmp_file=$(ls "${INPUT_PROJECTBASEDIR}/" | head -1)
-PERM=$(stat -c "%u:%g" "${INPUT_PROJECTBASEDIR}/$_tmp_file")
-
-chown -R $PERM "${INPUT_PROJECTBASEDIR}/"

--- a/test/run-qa.sh
+++ b/test/run-qa.sh
@@ -91,6 +91,7 @@ success "Correctly failed fast."
 info "Analyze project..."
 cd test/example-project/
 docker run -v `pwd`:/github/workspace/ --workdir /github/workspace --network $network --env INPUT_PROJECTBASEDIR=/github/workspace --env SONAR_TOKEN=$token --env SONAR_HOST_URL='http://sonarqube:9000' sonarsource/sonarqube-scan-action
+docker run -v `pwd`:/github/workspace/ --workdir /github/workspace --network $network --env INPUT_PROJECTBASEDIR=/github/workspace --entrypoint /cleanup.sh sonarsource/sonarqube-scan-action
 if [[ ! $? -eq 0 ]]; then
   error "Couldn't run the analysis."
   exit 1


### PR DESCRIPTION
This contribution is made to fix the issue #31.

We are using the post-entrypoint property of the `docker` github action to run the cleanup and but set the right permissions to all workspace file.

In this case if the scan action fails or is cancelled, the post-action will run and set the right permissions to all files.

