### PR TITLE
ci: publish v1 and v1.1 tags

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -1,0 +1,32 @@
+name: Update Tags
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Parse semver
+        uses: madhead/semver-utils@v2
+        id: version
+        with:
+          version: ${{ github.ref_name }}
+
+      - name: Update tags
+        run: |
+          TAGS='v${{ steps.version.outputs.major }} v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}'
+          
+          for t in $TAGS; do
+            git tag -f "$t"
+            git push origin ":$t" 2>/dev/null || true
+            git push origin "$t"
+          done


### PR DESCRIPTION
This is standard for actions. Generates vX and vX.Y for new tag vX.Y.Z

Using master branch as version is an antipattern, and while using specific versions (v1.1.0 etc) is perfectly fine, updating such version across all workflows is very tedious, even with the help of Dependabot.

Workflow executes only on tag in `v*.*.*` format, and overwrites given tags.