### PR TITLE
Quote base project dir parameter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,5 +32,5 @@ fi
 
 unset JAVA_HOME
 
-sonar-scanner -Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR} ${INPUT_ARGS}
+sonar-scanner -Dsonar.projectBaseDir="${INPUT_PROJECTBASEDIR}" ${INPUT_ARGS}
 


### PR DESCRIPTION
The scan command fails if `projectBaseDir` contains a space character.