### PR TITLE
adds retries to make ARM docker startup not break 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,32 +8,32 @@ runs:
   using: "composite"
   steps:
     - id: setup1
-    uses: docker
-    image: Dockerfile
-    entrypoint: "/entrypoint.sh"
-    post-entrypoint: "/cleanup.sh"
-    continue-on-error: true
-  - id: setup2
-    if: steps.setup1.outcome == 'failure'
-    uses: docker
-    image: Dockerfile
-    entrypoint: "/entrypoint.sh"
-    post-entrypoint: "/cleanup.sh"
-    continue-on-error: true
-  - id: setup3
-    if: steps.setup2.outcome == 'failure'
-    uses: docker
-    image: Dockerfile
-    entrypoint: "/entrypoint.sh"
-    post-entrypoint: "/cleanup.sh"
-    continue-on-error: true
-  - id: setup4
-    if: steps.setup3.outcome == 'failure'
-    uses: docker
-    image: Dockerfile
-    entrypoint: "/entrypoint.sh"
-    post-entrypoint: "/cleanup.sh"
-    continue-on-error: true
+      uses: docker
+      image: Dockerfile
+      entrypoint: "/entrypoint.sh"
+      post-entrypoint: "/cleanup.sh"
+      continue-on-error: true
+    - id: setup2
+      if: steps.setup1.outcome == 'failure'
+      uses: docker
+      image: Dockerfile
+      entrypoint: "/entrypoint.sh"
+      post-entrypoint: "/cleanup.sh"
+      continue-on-error: true
+    - id: setup3
+      if: steps.setup2.outcome == 'failure'
+      uses: docker
+      image: Dockerfile
+      entrypoint: "/entrypoint.sh"
+      post-entrypoint: "/cleanup.sh"
+      continue-on-error: true
+    - id: setup4
+      if: steps.setup3.outcome == 'failure'
+      uses: docker
+      image: Dockerfile
+      entrypoint: "/entrypoint.sh"
+      post-entrypoint: "/cleanup.sh"
+      continue-on-error: true
 inputs:
   args:
     description: Additional arguments to the sonar-scanner

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,35 @@ branding:
   icon: check
   color: green
 runs:
-  using: docker
-  image: Dockerfile
-  entrypoint: "/entrypoint.sh"
-  post-entrypoint: "/cleanup.sh"
+  using: "composite"
+  steps:
+    - id: setup1
+    uses: docker
+    image: Dockerfile
+    entrypoint: "/entrypoint.sh"
+    post-entrypoint: "/cleanup.sh"
+    continue-on-error: true
+  - id: setup2
+    if: steps.setup1.outcome == 'failure'
+    uses: docker
+    image: Dockerfile
+    entrypoint: "/entrypoint.sh"
+    post-entrypoint: "/cleanup.sh"
+    continue-on-error: true
+  - id: setup3
+    if: steps.setup2.outcome == 'failure'
+    uses: docker
+    image: Dockerfile
+    entrypoint: "/entrypoint.sh"
+    post-entrypoint: "/cleanup.sh"
+    continue-on-error: true
+  - id: setup4
+    if: steps.setup3.outcome == 'failure'
+    uses: docker
+    image: Dockerfile
+    entrypoint: "/entrypoint.sh"
+    post-entrypoint: "/cleanup.sh"
+    continue-on-error: true
 inputs:
   args:
     description: Additional arguments to the sonar-scanner


### PR DESCRIPTION
Hello, if you add retries on the action the chance of #73 goes to zero, as the action normally needs a couple of retires to work for ARM builds.

Until a base `sonarsource/sonar-scanner-cli:5.0.1` for ARM is built this will solve the problem for ARM users transparently.

Feel free to merge upstream or not, I hope this snippet at least is useful anyway if anyone comes to the project for a solution to the ARM build failing so often. 