### PR TITLE
Allow for a base image to be defined to avoid rate limiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG INPUT_BASEIMAGE=sonarsource/sonar-scanner-cli:5.0.1
-FROM INPUT_BASEIMAGE
+FROM ${INPUT_BASEIMAGE}
 
 LABEL version="2.0.1" \
       repository="https://github.com/sonarsource/sonarqube-scan-action" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM sonarsource/sonar-scanner-cli:5.0.1
+ARG INPUT_BASEIMAGE=sonarsource/sonar-scanner-cli:5.0.1
+FROM INPUT_BASEIMAGE
 
 LABEL version="2.0.1" \
       repository="https://github.com/sonarsource/sonarqube-scan-action" \

--- a/README.md
+++ b/README.md
@@ -106,14 +106,25 @@ More information about possible analysis parameters can be found in [the documen
 - `SONAR_HOST_URL` – **Required** this tells the scanner where SonarQube is hosted. You can set the `SONAR_HOST_URL` environment variable in the "Secrets" settings page of your repository, or you can add them at the level of your GitHub organization (recommended).
 - `SONAR_ROOT_CERT` – Holds an additional root certificate (in PEM format) that is used to validate the SonarQube server certificate. You can set the `SONAR_ROOT_CERT` environment variable in the "Secrets" settings page of your repository, or you can add them at the level of your GitHub organization (recommended).
 
+### Alternative base image
+
+You can pass in the baseImage input argument to allow for a different base image to be used with the action. The primary use case for this is if you are experiencing rate limiting from the docker registry.
+
+```yaml
+- name: SonarQube Scan
+  uses: sonarsource/sonarqube-scan-action@master
+  with:
+    baseImage: dockerhub-remote.artifactory.mystuff.com/sonarsource/sonar-scanner-cli:5.0.1
+```
+
 ## Alternatives for Java, .NET, and C/C++ projects
 
 This GitHub Action will not work for all technologies. If you are in one of the following situations, you should use the following alternatives:
 
-* Your code is built with Maven. Read the documentation about our [Scanner for Maven](https://redirect.sonarsource.com/doc/install-configure-scanner-maven.html).
-* Your code is built with Gradle. Read the documentation about our [Scanner for Gradle](https://redirect.sonarsource.com/doc/gradle.html).
-* You want to analyze a .NET solution. Read the documentation about our [Scanner for .NET](https://redirect.sonarsource.com/doc/install-configure-scanner-msbuild.html).
-* You want to analyze C/C++ code. Read the documentation on [analyzing C/C++ code](https://docs.sonarqube.org/latest/analysis/languages/cfamily/).
+- Your code is built with Maven. Read the documentation about our [Scanner for Maven](https://redirect.sonarsource.com/doc/install-configure-scanner-maven.html).
+- Your code is built with Gradle. Read the documentation about our [Scanner for Gradle](https://redirect.sonarsource.com/doc/gradle.html).
+- You want to analyze a .NET solution. Read the documentation about our [Scanner for .NET](https://redirect.sonarsource.com/doc/install-configure-scanner-msbuild.html).
+- You want to analyze C/C++ code. Read the documentation on [analyzing C/C++ code](https://docs.sonarqube.org/latest/analysis/languages/cfamily/).
 
 ## Have questions or feedback?
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,8 @@ runs:
   image: Dockerfile
   entrypoint: "/entrypoint.sh"
   post-entrypoint: "/cleanup.sh"
+  args:
+    - ${{ inputs.baseImage }}
 inputs:
   args:
     description: Additional arguments to the sonar-scanner
@@ -17,3 +19,6 @@ inputs:
     description: Set the sonar.projectBaseDir analysis property
     required: false
     default: .
+  baseImage:
+    description: Allow for a different base image to be used from a private registry to avoid rate limiting.
+    required: false


### PR DESCRIPTION
Simple change that does not affect the current project but allows for a different base image to be used to avoid rate limiting when pulling from the docker registry. This allows companies to publish their own `sonarsource/sonar-scanner-cli:5.0.1` images and use them in self hosted runners. 
