### PR TITLE
Fix setting file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ LABEL version="2.0.1" \
       com.github.actions.icon="check" \
       com.github.actions.color="green"
 
-
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-COPY cleanup.sh /cleanup.sh
-RUN chmod +x /cleanup.sh
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+COPY --chmod=755 cleanup.sh /cleanup.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Fixes #104 

File permissions is set by the docker build engine, and does not depend on the user in base image.