### PR TITLE
remove Exit to avoid pipeline exits in GHA

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,13 +21,11 @@ if [[ -n "${SONAR_ROOT_CERT}" ]]; then
 fi
 
 if [[ -f "${INPUT_PROJECTBASEDIR%/}/pom.xml" ]]; then
-  echo "Maven project detected. You should run the goal 'org.sonarsource.scanner.maven:sonar' during build rather than using this GitHub Action."
-  exit 1
+  echo "WARNING! Maven project detected. You should run the goal 'org.sonarsource.scanner.maven:sonar' during build rather than using this GitHub Action."
 fi
 
 if [[ -f "${INPUT_PROJECTBASEDIR%/}/build.gradle" ]]; then
-  echo "Gradle project detected. You should use the SonarQube plugin for Gradle during build rather than using this GitHub Action."
-  exit 1
+  echo "WARNING! Gradle project detected. You should use the SonarQube plugin for Gradle during build rather than using this GitHub Action."
 fi
 
 unset JAVA_HOME


### PR DESCRIPTION
Removing the Exit. to just alert as Warning instead of quitting the job in CI Context. Although sonarqube is recommending using Gradle/Maven plugins to scan Java projects. Yet, some integrations in favor of Decoupling Dev Code from CI Code might prefer to use the Github Scanner action (to decouple Source Code from Scan Operations).

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Make sure any code you changed is covered by tests
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
