### PR TITLE
SQSCANGHA-38 Revert "SQSCANGHA-28 Support passing args with spaces"

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -19,13 +19,12 @@ jobs:
       - name: Run action with args
         uses: ./
         with:
-          args: >-
-            "-Dsonar.someArg=a value with spaces" -Dsonar.scanner.dumpToFile=./output.properties
+          args: -Dsonar.someArg=aValue -Dsonar.scanner.dumpToFile=./output.properties
         env:
           SONAR_HOST_URL: http://not_actually_used
       - name: Assert
         run: |
-          ./test/assertFileContains ./output.properties "sonar.someArg=a value with spaces"
+          ./test/assertFileContains ./output.properties "sonar.someArg=aValue"
   projectBaseDirInputTest:
     name: >
       'projectBaseDir' input

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,5 @@ fi
 
 unset JAVA_HOME
 
-eval "args=(${INPUT_ARGS})"
-sonar-scanner $debug_flag "-Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR}" "${args[@]}"
+sonar-scanner $debug_flag -Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR} ${INPUT_ARGS}
 


### PR DESCRIPTION
This reverts commit 16be80a08001cc68072c0b1eafb58f7abafc4a10.

It is required to Fix SQSCANGHA-38.

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Make sure any code you changed is covered by tests
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
