### PR TITLE
Prevent globbing and word splitting in `cleanup.sh`

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -10,4 +10,4 @@ echo "Reading permissions from $_tmp_file"
 PERM=$(stat -c "%u:%g" "${INPUT_PROJECTBASEDIR%/}/$_tmp_file")
 
 echo "Applying permissions $PERM to all files in the project base directory"
-chown -R $PERM "${INPUT_PROJECTBASEDIR%/}/"
+chown -R "$PERM" "${INPUT_PROJECTBASEDIR%/}/"


### PR DESCRIPTION
Not using double quotes here might cause _globbing and word splitting_ (cf. [SC2086](https://www.shellcheck.net/wiki/SC2086)).

Essentially same as SonarSource/sonarcloud-github-action#84. Because of the reasons discussed there, I did not update [`entrypoint.sh`](https://github.com/SonarSource/sonarqube-scan-action/blob/bfafdf2896c713c5d4172ee174843c7207810bc8/entrypoint.sh#L35).

Similar to SonarSource/sonarcloud-github-c-cpp#60.