### PR TITLE
SQSCANGHA-51 Make Scanner CLI binaries URL customizable

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -68,6 +68,54 @@ jobs:
       - name: Assert
         run: |
           ./test/assertFileContains ./output.properties "sonar.projectBaseDir=.*/baseDir"
+  scannerVersionTest:
+    name: >
+      'scannerVersion' input
+    runs-on: ubuntu-latest # assumes default RUNNER_ARCH for linux is X64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run action with scannerVersion
+        uses: ./
+        with:
+          scannerVersion: 6.1.0.4477
+          args: -Dsonar.scanner.internal.dumpToFile=./output.properties
+        env:
+          NO_CACHE: true # force install-sonar-scanner-cli.sh execution
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output.properties"}'
+      - name: Assert
+        run: |
+          ./test/assertFileExists "$RUNNER_TEMP/sonarscanner/sonar-scanner-cli-6.1.0.4477-linux-x64.zip"
+  scannerBinariesUrlTest:
+    name: >
+      'scannerBinariesUrl' input with invalid URL
+    runs-on: ubuntu-latest # assumes default RUNNER_ARCH for linux is X64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run action with scannerBinariesUrl
+        id: runTest
+        uses: ./
+        continue-on-error: true
+        with:
+          scannerVersion: 6.2.1.4610
+          scannerBinariesUrl: https://invalid_uri/Distribution/sonar-scanner-cli
+        env:
+          NO_CACHE: true # force install-sonar-scanner-cli.sh execution
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output.properties"}'
+      - name: Fail if action succeeded
+        if: steps.runTest.outcome == 'success'
+        run: exit 1
+      - name: Assert Sonar Scanner CLI was not downloaded
+        run: |
+          ./test/assertFileDoesntExist "$RUNNER_TEMP/sonarscanner/sonar-scanner-cli-6.2.1.4610-linux-x64.zip"
+      - name: Assert Sonar Scanner CLI was not executed
+        run: |
+          ./test/assertFileDoesntExist ./output.properties
   dontFailGradleTest:
     name: >
       Don't fail on Gradle project

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Version of the Sonar Scanner CLI to use
     required: false
     default: 6.2.1.4610
+  scannerBinariesUrl:
+    description: URL to download the Sonar Scanner CLI binaries from
+    required: false
+    default: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli
 runs:
   using: "composite"
   steps:
@@ -30,11 +34,12 @@ runs:
         path: ${{ runner.temp }}/sonar-scanner-cli-${{ inputs.scannerVersion }}-${{ runner.os }}-${{ runner.arch }}
         key: sonar-scanner-cli-${{ inputs.scannerVersion }}-${{ runner.os }}-${{ runner.arch }}
     - name: Install Sonar Scanner CLI
-      if: steps.sonar-scanner-cli.outputs.cache-hit != 'true'
+      if: ${{ env.NO_CACHE == 'true' || steps.sonar-scanner-cli.outputs.cache-hit != 'true' }}
       run: ${GITHUB_ACTION_PATH}/install-sonar-scanner-cli.sh
       shell: bash
       env:
         INPUT_SCANNERVERSION: ${{ inputs.scannerVersion }}
+        INPUT_SCANNERBINARIESURL: ${{ inputs.scannerBinariesUrl }}
     - name: Add SonarScanner CLI to the PATH
       run: echo "${RUNNER_TEMP}/sonar-scanner-cli-${{ inputs.scannerVersion }}-${{ runner.os }}-${{ runner.arch }}/bin" >> $GITHUB_PATH
       shell: bash

--- a/install-sonar-scanner-cli.sh
+++ b/install-sonar-scanner-cli.sh
@@ -26,7 +26,7 @@ set -x
 mkdir -p $RUNNER_TEMP/sonarscanner
 cd $RUNNER_TEMP/sonarscanner
 
-$WGET --no-verbose --user-agent="sonarqube-scan-action" https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip
+$WGET --no-verbose --user-agent="sonarqube-scan-action" "${INPUT_SCANNERBINARIESURL%/}/sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip"
 
 unzip -q sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip
 

--- a/test/assertFileDoesntExist
+++ b/test/assertFileDoesntExist
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+error() { echo -e "\\e[31m✗ $*\\e[0m"; }
+
+if [ -f $1 ]; then
+  error "File '$1' found"
+  exit 1
+fi


### PR DESCRIPTION
### Why
CI pipelines in environments that impose strict control to the access to the www fail the wget instruction to download Sonar Scanner CLI from the sonarsource binaries site. 

For those scenarios, we need to add additional parameters that users can use to point to a custom repository of binaries.

### What
This PR introduces a new optional `scannerBinariesUrl` action parameter, that allows to set the URI to the CLI. The URI is up to the `sonarscanner` directory included (`https://binaries.sonarsource.com/Distribution/sonar-scanner-cli`), and doesn't include the name of the file (e.g. `sonar-scanner-cli-6.2.1.4610-linux-x64.zip`) since the name of the file depends on operating system (`RUNNER_OS`) and architecture (`RUNNER_ARCH`).

```yaml
    - name: Dart Scan
      uses: sonarsource/sonarqube-scan-action@antonio/binaries-url-config
      env:
        SONAR_HOST_URL: http://localhost:9000
      with:
        scannerBinariesUrl: https://my.custom.binaries.url.com/Distribution/sonar-scanner-cli/
```

The new `scannerBinariesUrl` action parameter includes `Distribution/sonarscanner` so that's easy for a user who need to change it to a custom repo, to point to any directory, without the need to recreate the `Distribution/sonarscanner` structure.

This means that, the day we will need to download another resource from `binaries.sonarsource.com`, we will need to add another parameter. Build wrapper, however, won't pose such a problem since it is downloaded from SonarQube. 

### Builds

Successful build with default value: https://github.com/antonioaversa/dart-tools-test1/actions/runs/11897272492/job/33151305671#step:4:40
Successful build with explicit default value (terminal slash): https://github.com/antonioaversa/dart-tools-test1/actions/runs/11896758678/job/33149767749#step:4:40
Successful build with a different URI, containing the required binary: https://github.com/antonioaversa/dart-tools-test1/actions/runs/11896649263/job/33149029847#step:4:40
Failing build with a different URI, non-containing the required binary: https://github.com/antonioaversa/dart-tools-test1/actions/runs/11896323568/job/33148487407#step:4:43