### PR TITLE
SQSCANGHA-55 Support GitHub self-hosted runners without wget

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -269,6 +269,60 @@ jobs:
       - name: Assert
         run: |
           ./test/assertFileExists ./test/example-project/.scannerwork/report-task.txt        
+  dontFailOnMissingWget:
+    name: Don't fail on missing wget
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove wget
+        run: sudo apt-get remove -y wget
+      - name: Assert wget is not available
+        run: |
+          if command -v wget 2>&1 >/dev/null
+          then
+            exit 1
+          fi
+      - name: Run action
+        uses: ./
+        env:
+          NO_CACHE: true
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output.properties"}'
+        with:
+          args: -Dsonar.scanner.internal.dumpToFile=./output.properties
+      - name: Assert
+        run: |
+          ./test/assertFileExists ./output.properties
+  failOnMissingCurl:
+    name: Fail on missing curl
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove curl
+        run: sudo apt-get remove -y curl
+      - name: Assert curl is not available
+        run: |
+          if command -v curl 2>&1 >/dev/null
+          then
+            exit 1
+          fi
+      - name: Run action
+        id: runTest
+        uses: ./
+        continue-on-error: true
+        env:
+          NO_CACHE: true
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output.properties"}'
+        with:
+          args: -Dsonar.scanner.internal.dumpToFile=./output.properties
+      - name: Assert failure of previous step
+        if: steps.runTest.outcome == 'success'
+        run: exit 1
   useSslCertificate:
     name: >
       'SONAR_ROOT_CERT' is converted to truststore

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -269,8 +269,8 @@ jobs:
       - name: Assert
         run: |
           ./test/assertFileExists ./test/example-project/.scannerwork/report-task.txt        
-  dontFailOnMissingWget:
-    name: Don't fail on missing wget
+  dontFailWhenMissingWgetButCurlAvailable:
+    name: Don't fail when missing wget but curl available
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -295,8 +295,8 @@ jobs:
       - name: Assert
         run: |
           ./test/assertFileExists ./output.properties
-  failOnMissingCurl:
-    name: Fail on missing curl
+  dontFailWhenMissingCurlButWgetAvailable:
+    name: Don't fail when missing curl but wget available
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -306,6 +306,37 @@ jobs:
         run: sudo apt-get remove -y curl
       - name: Assert curl is not available
         run: |
+          if command -v curl 2>&1 >/dev/null
+          then
+            exit 1
+          fi
+      - name: Run action
+        id: runTest
+        uses: ./
+        env:
+          NO_CACHE: true
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output.properties"}'
+        with:
+          args: -Dsonar.scanner.internal.dumpToFile=./output.properties
+      - name: Assert
+        run: |
+          ./test/assertFileExists ./output.properties
+  failWhenBothWgetAndCurlMissing:
+    name: Fail when both wget and curl are missing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove wget and curl
+        run: sudo apt-get remove -y wget curl
+      - name: Assert wget and curl are not available
+        run: |
+          if command -v wget 2>&1 >/dev/null
+          then
+            exit 1
+          fi
           if command -v curl 2>&1 >/dev/null
           then
             exit 1

--- a/install-sonar-scanner-cli.sh
+++ b/install-sonar-scanner-cli.sh
@@ -8,21 +8,39 @@ set -eou pipefail
 # - INPUT_SCANNERVERSION: e.g. 6.2.1.4610
 # - INPUT_SCANNERBINARIESURL: e.g. https://github.com/me/my-repo/raw/refs/heads/main/binaries
 
-CURL=curl
-if [[ "$RUNNER_OS" == "Linux" &&  "$RUNNER_ARCH" == "X64" ]]; then
+if [[ "$RUNNER_OS" == "Linux" && "$RUNNER_ARCH" == "X64" ]]; then
      FLAVOR="linux-x64"
-elif [[ "$RUNNER_OS" == "Linux" &&  "$RUNNER_ARCH" == "ARM64" ]]; then
+elif [[ "$RUNNER_OS" == "Linux" && "$RUNNER_ARCH" == "ARM64" ]]; then
      FLAVOR="linux-aarch64"
-elif [[ "$RUNNER_OS" == "Windows" &&  "$RUNNER_ARCH" == "X64" ]]; then
+elif [[ "$RUNNER_OS" == "Windows" && "$RUNNER_ARCH" == "X64" ]]; then
      FLAVOR="windows-x64"
-     CURL="C:\\msys64\\usr\\bin\\curl.exe"
-elif [[ "$RUNNER_OS" == "macOS" &&  "$RUNNER_ARCH" == "X64" ]]; then
+elif [[ "$RUNNER_OS" == "macOS" && "$RUNNER_ARCH" == "X64" ]]; then
      FLAVOR="macosx-x64"
-elif [[ "$RUNNER_OS" == "macOS" &&  "$RUNNER_ARCH" == "ARM64" ]]; then
+elif [[ "$RUNNER_OS" == "macOS" && "$RUNNER_ARCH" == "ARM64" ]]; then
      FLAVOR="macosx-aarch64"
 else
-     echo "$RUNNER_OS $RUNNER_ARCH not supported"
+     echo "::error title=SonarScanner::$RUNNER_OS $RUNNER_ARCH not supported"
      exit 1
+fi
+
+SCANNER_FILE_NAME="sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip"
+SCANNER_URI="${INPUT_SCANNERBINARIESURL%/}/$SCANNER_FILE_NAME"
+
+if command -v wget &> /dev/null; then
+    DOWNLOAD_COMMAND="wget"
+    DOWNLOAD_ARGS="--no-verbose --user-agent=sonarqube-scan-action $SCANNER_URI"
+elif command -v curl &> /dev/null; then
+    DOWNLOAD_COMMAND="curl"
+    DOWNLOAD_ARGS="--silent --show-error --user-agent sonarqube-scan-action --output $SCANNER_FILE_NAME $SCANNER_URI"
+elif [ "$RUNNER_OS" == "Windows" ] && [ -t "C:\\msys64\\usr\\bin\\wget.exe" ]; then
+    DOWNLOAD_COMMAND="C:\\msys64\\usr\\bin\\wget.exe"
+    DOWNLOAD_ARGS="--no-verbose --user-agent=sonarqube-scan-action $SCANNER_URI"
+elif [ "$RUNNER_OS" == "Windows" ] && [ -t "C:\\msys64\\usr\\bin\\curl.exe" ]; then
+    DOWNLOAD_COMMAND="C:\\msys64\\usr\\bin\\curl.exe"
+    DOWNLOAD_ARGS="--silent --show-error --user-agent sonarqube-scan-action --output $SCANNER_FILE_NAME $SCANNER_URI"
+else
+    echo "::error title=SonarScanner::Neither wget nor curl found on the machine"
+    exit 1
 fi
 
 set -x
@@ -30,9 +48,7 @@ set -x
 mkdir -p $RUNNER_TEMP/sonarscanner
 cd $RUNNER_TEMP/sonarscanner
 
-SCANNER_FILE_NAME="sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip"
-SCANNER_URI="${INPUT_SCANNERBINARIESURL%/}/$SCANNER_FILE_NAME"
-$CURL --user-agent "sonarqube-scan-action" --output $SCANNER_FILE_NAME $SCANNER_URI
+$DOWNLOAD_COMMAND $DOWNLOAD_ARGS
 
 unzip -q $SCANNER_FILE_NAME
 

--- a/install-sonar-scanner-cli.sh
+++ b/install-sonar-scanner-cli.sh
@@ -2,16 +2,20 @@
 
 set -eou pipefail
 
-#See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+# See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+#
+# Script-specific variables required:
+# - INPUT_SCANNERVERSION: e.g. 6.2.1.4610
+# - INPUT_SCANNERBINARIESURL: e.g. https://github.com/me/my-repo/raw/refs/heads/main/binaries
 
-WGET=wget
+CURL=curl
 if [[ "$RUNNER_OS" == "Linux" &&  "$RUNNER_ARCH" == "X64" ]]; then
      FLAVOR="linux-x64"
 elif [[ "$RUNNER_OS" == "Linux" &&  "$RUNNER_ARCH" == "ARM64" ]]; then
      FLAVOR="linux-aarch64"
 elif [[ "$RUNNER_OS" == "Windows" &&  "$RUNNER_ARCH" == "X64" ]]; then
      FLAVOR="windows-x64"
-     WGET="C:\\msys64\\usr\\bin\\wget.exe"
+     CURL="C:\\msys64\\usr\\bin\\curl.exe"
 elif [[ "$RUNNER_OS" == "macOS" &&  "$RUNNER_ARCH" == "X64" ]]; then
      FLAVOR="macosx-x64"
 elif [[ "$RUNNER_OS" == "macOS" &&  "$RUNNER_ARCH" == "ARM64" ]]; then
@@ -26,9 +30,11 @@ set -x
 mkdir -p $RUNNER_TEMP/sonarscanner
 cd $RUNNER_TEMP/sonarscanner
 
-$WGET --no-verbose --user-agent="sonarqube-scan-action" "${INPUT_SCANNERBINARIESURL%/}/sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip"
+SCANNER_FILE_NAME="sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip"
+SCANNER_URI="${INPUT_SCANNERBINARIESURL%/}/$SCANNER_FILE_NAME"
+$CURL --user-agent "sonarqube-scan-action" --output $SCANNER_FILE_NAME $SCANNER_URI
 
-unzip -q sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip
+unzip -q $SCANNER_FILE_NAME
 
 # Folder name should correspond to the directory cached by the actions/cache
 mv sonar-scanner-$INPUT_SCANNERVERSION-$FLAVOR $RUNNER_TEMP/sonar-scanner-cli-$INPUT_SCANNERVERSION-$RUNNER_OS-$RUNNER_ARCH


### PR DESCRIPTION
Replaces `wget` with `curl`.

~The base of this PR is https://github.com/SonarSource/sonarqube-scan-action/pull/148, as it builds on top of it.~

~The PR is kept in draft to avoid accidental merging.~

UPDATE: https://github.com/SonarSource/sonarqube-scan-action/pull/148 has been merged, so now this PR directly targets `dev`.