### PR TITLE
SQSCANGHA-55 Add curl redirect and fix splatting of URL with special chars

### DIFF
--- a/.github/qa-nginx-redirecting/compose.yml
+++ b/.github/qa-nginx-redirecting/compose.yml
@@ -1,0 +1,13 @@
+services:
+  https-proxy:
+    image: nginx
+    ports:
+      - 8080:8080
+    volumes:
+      - $GITHUB_WORKSPACE/.github/qa-nginx-redirecting/nginx.conf:/etc/nginx/nginx.conf:ro
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 2m

--- a/.github/qa-nginx-redirecting/nginx.conf
+++ b/.github/qa-nginx-redirecting/nginx.conf
@@ -24,20 +24,9 @@ http {
             add_header 'Content-Type' 'text/plain';
             return 200 "healthy\n";
         }
-    }
 
-    server {
-        listen 4443 ssl;
-
-        ssl_protocols TLSv1.1 TLSv1.2;
-        ssl_certificate /etc/nginx/server.crt;
-        ssl_certificate_key /etc/nginx/server.key;
-
-        location / {
-            proxy_pass http://sonarqube:9000;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $remote_addr;
-            proxy_set_header X-Forwarded-Proto https;
+        location ~ /clientRedirectToSonarBinaries/(.*) {
+            return 301 "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/$1";
         }
     }
 }

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -116,6 +116,56 @@ jobs:
       - name: Assert Sonar Scanner CLI was not executed
         run: |
           ./test/assertFileDoesntExist ./output.properties
+  scannerBinariesUrlIsEscapedWithWget:
+    name: >
+      'scannerBinariesUrl' is escaped with wget so special chars are not injected in the download command
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run action with scannerBinariesUrl
+        id: runTest
+        uses: ./
+        continue-on-error: true
+        with:
+          scannerBinariesUrl: 'http://some_uri;touch file.txt;'
+        env:
+          NO_CACHE: true
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output1.properties"}'
+      - name: Assert file.txt does not exist
+        run: |
+          ./test/assertFileDoesntExist "$RUNNER_TEMP/sonarscanner/file.txt"
+  scannerBinariesUrlIsEscapedWithCurl:
+    name: >
+      'scannerBinariesUrl' is escaped with curl so special chars are not injected in the download command
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove wget
+        run: sudo apt-get remove -y wget
+      - name: Assert wget is not available
+        run: |
+          if command -v wget 2>&1 >/dev/null
+          then
+            exit 1
+          fi
+      - name: Run action with scannerBinariesUrl
+        id: runTest
+        uses: ./
+        continue-on-error: true
+        with:
+          scannerBinariesUrl: 'http://some_uri http://another_uri''; touch file.txt;'
+        env:
+          NO_CACHE: true
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output1.properties"}'
+      - name: Assert file.txt does not exist
+        run: |
+          ./test/assertFileDoesntExist "$RUNNER_TEMP/sonarscanner/file.txt"
   dontFailGradleTest:
     name: >
       Don't fail on Gradle project
@@ -376,6 +426,37 @@ jobs:
       - name: Assert failure of previous step
         if: steps.runTest.outcome == 'success'
         run: exit 1
+  curlPerformsRedirect:
+    name: >
+      curl performs redirect when scannerBinariesUrl returns 3xx
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove wget
+        run: sudo apt-get remove -y wget
+      - name: Assert wget is not available
+        run: |
+          if command -v wget 2>&1 >/dev/null
+          then
+            exit 1
+          fi
+      - name: Start nginx via Docker Compose
+        run: docker compose up -d --wait
+        working-directory: .github/qa-nginx-redirecting
+      - name: Run action with scannerBinariesUrl
+        id: runTest
+        uses: ./
+        with:
+          scannerBinariesUrl: http://localhost:8080/clientRedirectToSonarBinaries
+        env:
+          NO_CACHE: true
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output1.properties"}'
+      - name: Assert Sonar Scanner CLI was downloaded
+        run: |
+          ./test/assertFileExists "$RUNNER_TEMP/sonarscanner/sonar-scanner-cli-6.2.1.4610-linux-x64.zip"
   useSslCertificate:
     name: >
       'SONAR_ROOT_CERT' is converted to truststore

--- a/install-sonar-scanner-cli.sh
+++ b/install-sonar-scanner-cli.sh
@@ -23,32 +23,28 @@ else
      exit 1
 fi
 
-SCANNER_FILE_NAME="sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip"
-SCANNER_URI="${INPUT_SCANNERBINARIESURL%/}/$SCANNER_FILE_NAME"
-
-if command -v wget &> /dev/null; then
-    DOWNLOAD_COMMAND="wget"
-    DOWNLOAD_ARGS="--no-verbose --user-agent=sonarqube-scan-action $SCANNER_URI"
-elif command -v curl &> /dev/null; then
-    DOWNLOAD_COMMAND="curl"
-    DOWNLOAD_ARGS="--silent --show-error --user-agent sonarqube-scan-action --output $SCANNER_FILE_NAME $SCANNER_URI"
-elif [ "$RUNNER_OS" == "Windows" ] && [ -t "C:\\msys64\\usr\\bin\\wget.exe" ]; then
-    DOWNLOAD_COMMAND="C:\\msys64\\usr\\bin\\wget.exe"
-    DOWNLOAD_ARGS="--no-verbose --user-agent=sonarqube-scan-action $SCANNER_URI"
-elif [ "$RUNNER_OS" == "Windows" ] && [ -t "C:\\msys64\\usr\\bin\\curl.exe" ]; then
-    DOWNLOAD_COMMAND="C:\\msys64\\usr\\bin\\curl.exe"
-    DOWNLOAD_ARGS="--silent --show-error --user-agent sonarqube-scan-action --output $SCANNER_FILE_NAME $SCANNER_URI"
-else
-    echo "::error title=SonarScanner::Neither wget nor curl found on the machine"
-    exit 1
-fi
-
 set -x
 
 mkdir -p $RUNNER_TEMP/sonarscanner
 cd $RUNNER_TEMP/sonarscanner
 
-$DOWNLOAD_COMMAND $DOWNLOAD_ARGS
+SCANNER_FILE_NAME="sonar-scanner-cli-$INPUT_SCANNERVERSION-$FLAVOR.zip"
+SCANNER_URI="${INPUT_SCANNERBINARIESURL%/}/$SCANNER_FILE_NAME"
+
+if command -v wget &> /dev/null; then
+    wget --no-verbose --user-agent=sonarqube-scan-action "$SCANNER_URI"
+elif command -v curl &> /dev/null; then
+    curl --fail --silent --show-error --user-agent sonarqube-scan-action \
+         --location --output "$SCANNER_FILE_NAME" "$SCANNER_URI"
+elif [ "$RUNNER_OS" == "Windows" ] && [ -t "C:\\msys64\\usr\\bin\\wget.exe" ]; then
+    "C:\\msys64\\usr\\bin\\wget.exe" --no-verbose --user-agent=sonarqube-scan-action "$SCANNER_URI"
+elif [ "$RUNNER_OS" == "Windows" ] && [ -t "C:\\msys64\\usr\\bin\\curl.exe" ]; then
+    "C:\\msys64\\usr\\bin\\curl.exe" --fail --silent --show-error --user-agent sonarqube-scan-action \
+         --location --output "$SCANNER_FILE_NAME" "$SCANNER_URI"
+else
+    echo "::error title=SonarScanner::Neither wget nor curl found on the machine"
+    exit 1
+fi
 
 unzip -q $SCANNER_FILE_NAME
 


### PR DESCRIPTION
This PR makes a few improvements on top of https://ngithub.com/SonarSource/sonarqube-scan-action/pull/151:
- `curl` should auto-redirect on 3XX
- `curl` should fail right away on non-2XX (except for redirect)
- splatting of `curl` and `wget` parameters should be done safely, to avoid the risk of command injection via custom SonarScanner URL

I couldn't actually find myself a scenario where the splatting would lead to commands injections (which would be done by the user on the user-owned environment anyway), since parameters are passed in the yaml and are always escaped by single quote (see [this example](https://github.com/SonarSource/sonarqube-scan-action/actions/runs/12068750215/job/33654545394?pr=154#step:5:57)).

Anyway, I have added QA tests to document the behavior.