### PR TITLE
SQSCANGHA-64 Shorten action description to respect 125 chars limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,7 @@
 name: Official SonarQube (Server, Cloud) Scan
 description: >
-  Scan your code with SonarQube Server and Cloud to detect coding 
-  issues in 30+ languages, frameworks, and IaC platforms. 
-  The solution also provides fix recommendations leveraging AI with 
-  Sonar's AI CodeFix capability. (Formerly SonarQube and SonarCloud)
+  Scan your code with SonarQube Server and Cloud to detect 
+  issues in 30+ languages. (Formerly SonarQube and SonarCloud)
 branding:
   icon: check
   color: green


### PR DESCRIPTION
Part of MMF-4138

As noticed for `sonarcloud-github-action` and fixed [here](https://github.com/SonarSource/sonarcloud-github-action/pull/99), action descriptions should be shorter than 125 chars.
![image](https://github.com/user-attachments/assets/655d8495-47d2-44fa-86e9-c0aadbf500ca)