### PR TITLE
Force unzip without prompt in sonar scanner installation when files already exist

### DIFF
--- a/scripts/install-sonar-scanner-cli.sh
+++ b/scripts/install-sonar-scanner-cli.sh
@@ -46,7 +46,7 @@ else
     exit 1
 fi
 
-unzip -q $SCANNER_FILE_NAME
+unzip -q -o $SCANNER_FILE_NAME
 
 # Folder name should correspond to the directory cached by the actions/cache
 mv sonar-scanner-$INPUT_SCANNERVERSION-$FLAVOR $RUNNER_TEMP/sonar-scanner-cli-$INPUT_SCANNERVERSION-$RUNNER_OS-$RUNNER_ARCH


### PR DESCRIPTION
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Make sure any code you changed is covered by tests
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
------

This PR aims to fix the issue of failing installation for sonar scanner.

Workflow file:
```yaml

 - name: SonarQube Scan
        continue-on-error: false
        uses: sonarsource/sonarqube-scan-action@master
        with:
          projectBaseDir: api
          args: >
            ...
        env:
          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
```

Error log for action:
```
Run sonarsource/sonarqube-scan-action@master
Run ${GITHUB_ACTION_PATH}/sanity-checks.sh
Run actions/cache@v4.0.2
Cache not found for input keys: sonar-scanner-cli-6.2.1.4610-Linux-X64
Run ${GITHUB_ACTION_PATH}/install-sonar-scanner-cli.sh
+ mkdir -p /home/xxxx/actions-runner/_work/_temp/sonarscanner
+ cd /home/xxx/actions-runner/_work/_temp/sonarscanner
+ SCANNER_FILE_NAME=sonar-scanner-cli-6.2.1.4610-linux-x64.zip
+ SCANNER_URI=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.2.1.4610-linux-x64.zip
+ command -v wget
+ wget --no-verbose --user-agent=sonarqube-scan-action https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.2.1.4610-linux-x64.zip
2024-12-11 17:16:42 URL:https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.2.1.4610-linux-x64.zip [57996219/57996219] -> "sonar-scanner-cli-6.2.1.4610-linux-x64.zip.6" [1]
+ unzip -q sonar-scanner-cli-6.2.1.4610-linux-x64.zip
replace sonar-scanner-6.2.1.4610-linux-x64/jre/conf/sound.properties? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
Error: Process completed with exit code 1.
```
