### PR TITLE
SQSCANGHA-75 Support self-hosted runners not clearing temp after run

### DIFF
--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -619,3 +619,38 @@ jobs:
       - name: Assert failure of previous step
         if: steps.wrong_ssl_certificate.outcome == 'success'
         run: exit 1
+  overridesScannerLocalFolderWhenPresent:
+    name: >
+      'SCANNER_LOCAL_FOLDER' is overridden with warning when present
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create a dummy SCANNER_LOCAL_FOLDER with dummy content in it
+        run: |
+          SCANNER_VERSION="6.2.1.4610"
+          SCANNER_LOCAL_FOLDER="$RUNNER_TEMP/sonar-scanner-cli-$SCANNER_VERSION-$RUNNER_OS-$RUNNER_ARCH"
+          # emit SCANNER_VERSION and SCANNER_LOCAL_FOLDER to be able to read them in the next steps
+          echo "SCANNER_VERSION=$SCANNER_VERSION" >> $GITHUB_ENV
+          echo "SCANNER_LOCAL_FOLDER=$SCANNER_LOCAL_FOLDER" >> $GITHUB_ENV
+          mkdir -p "$SCANNER_LOCAL_FOLDER"
+          touch "$SCANNER_LOCAL_FOLDER/some_content.txt"
+      - name: Assert SCANNER_LOCAL_FOLDER exists and dummy file is in it
+        run: |
+          [ -d "$SCANNER_LOCAL_FOLDER" ] || exit 1
+          [ -f "$SCANNER_LOCAL_FOLDER/some_content.txt" ] || exit 1
+      - name: Run action with SONAR_SCANNER_TEMP
+        uses: ./
+        env:
+          SONAR_SCANNER_TEMP: /tmp/sonar-scanner
+          SONAR_HOST_URL: http://not_actually_used
+          NO_CACHE: true # force install-sonar-scanner-cli.sh execution
+        with:
+          args: -Dsonar.scanner.internal.dumpToFile=./output.properties
+          scannerVersion: ${{ env.SCANNER_VERSION }}
+      - name: Assert SCANNER_LOCAL_FOLDER exists and dummy file is not in it
+        run: |
+          [ -d "$SCANNER_LOCAL_FOLDER" ] || exit 1
+          [ ! -f "$SCANNER_LOCAL_FOLDER/some_content.txt" ] || exit 1
+

--- a/scripts/install-sonar-scanner-cli.sh
+++ b/scripts/install-sonar-scanner-cli.sh
@@ -48,5 +48,13 @@ fi
 
 unzip -q -o $SCANNER_FILE_NAME
 
+SCANNER_UNZIP_FOLDER="sonar-scanner-$INPUT_SCANNERVERSION-$FLAVOR"
 # Folder name should correspond to the directory cached by the actions/cache
-mv sonar-scanner-$INPUT_SCANNERVERSION-$FLAVOR $RUNNER_TEMP/sonar-scanner-cli-$INPUT_SCANNERVERSION-$RUNNER_OS-$RUNNER_ARCH
+SCANNER_LOCAL_FOLDER="$RUNNER_TEMP/sonar-scanner-cli-$INPUT_SCANNERVERSION-$RUNNER_OS-$RUNNER_ARCH"
+
+if [ -d "$SCANNER_LOCAL_FOLDER" ]; then
+     echo "::warning title=SonarScanner::Cleaning existing scanner folder: $SCANNER_LOCAL_FOLDER"
+     rm -rf "$SCANNER_LOCAL_FOLDER"
+fi
+
+mv -f "$SCANNER_UNZIP_FOLDER" "$SCANNER_LOCAL_FOLDER"


### PR DESCRIPTION
~**On top of https://github.com/SonarSource/sonarqube-scan-action/pull/161
Kept as draft to avoid accidental merging onto https://github.com/SonarSource/sonarqube-scan-action/pull/161**~

[SQSCANGHA-75](https://sonarsource.atlassian.net/browse/SQSCANGHA-75)

Related to [this community post](https://community.sonarsource.com/t/sonarsource-sonarqube-scan-action-master-failed-to-install-sonar-scanner-cli/131896)

[SQSCANGHA-75]: https://sonarsource.atlassian.net/browse/SQSCANGHA-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Example of warning behavior [here](https://github.com/SonarSource/sonarqube-scan-action/actions/runs/12318249500/job/34382574948#step:5:73)