### PR TITLE
SQSCANGHA-77 Change title back to SonarQube Scan Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
-name: Official SonarQube (Server, Cloud) Scan
+name: Official SonarQube Scan
+# Warning: changing name would change URL in the marketplace
 description: >
   Scan your code with SonarQube Server and Cloud to detect 
   issues in 30+ languages. (Formerly SonarQube and SonarCloud)


### PR DESCRIPTION
[SQSCANGHA-77](https://sonarsource.atlassian.net/browse/SQSCANGHA-77)

Releasing `sonarqube-scan-action@v4.2.0` [here](https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v4.2.0), has changed the URL of the action in the marketplace from  [Official SonarQube Scan - GitHub Marketplace](https://github.com/marketplace/actions/official-sonarqube-scan)  to [Official SonarQube (Server, Cloud) Scan - GitHub Marketplace](https://github.com/marketplace/actions/official-sonarqube-server-cloud-scan) .


The change of title of the action was done in a previous release (`v4.0.0`), but the change of URL happen right after `v4.2.0`.
Probably, it's because this is the first release we do from `master` (`v4.0.0` and `v4.1.0` were released from the dev branch), and that triggered a change of URL in GitHub.

Unfortunately, the old link seems broken. While it's not used to refer to the action in workflows, we use that URL in documentation and community posts.

So we need to change back the title of the action from `Official SonarQube (Server, Cloud) Scan` to `Official SonarQube Scan` and do a small bug-fix release `v4.2.1`.

[SQSCANGHA-77]: https://sonarsource.atlassian.net/browse/SQSCANGHA-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ