### PR TITLE
SQSCANGHA-80 Fix permission of the version_update workflow

### DIFF
--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -8,6 +8,9 @@ jobs:
   update-version:
     name: Prepare pull request for sonar-scanner version update
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - run: sudo apt install -y jq
 
@@ -34,7 +37,7 @@ jobs:
         shell: bash
         env:
           UPDATE_BRANCH: update-to-sonar-scanner-${{ steps.latest-version.outputs.sonar-scanner-version }}
-          TITLE: "Update sonar-scanner-version to ${{ steps.latest-version.outputs.sonar-scanner-version }}"
+          TITLE: "Update SonarScanner CLI to ${{ steps.latest-version.outputs.sonar-scanner-version }}"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "SonarTech"


### PR DESCRIPTION
[SQSCANGHA-80](https://sonarsource.atlassian.net/browse/SQSCANGHA-80)

The task was [failing](https://github.com/SonarSource/sonarqube-scan-action/actions/workflows/version_update.yml) for a few weeks. Maybe something changed on GitHub side.