### PR TITLE
SQSCANGHA-82 Automate the update of the Scanner CLI version

### DIFF
--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - run: sudo apt install -y jq
-
+      - run: sudo snap install yq
       - uses: actions/checkout@v4
         with:
           ref: master
@@ -31,7 +31,13 @@ jobs:
         run: |
           ./scripts/fetch_latest_version.sh > sonar-scanner-version
           cat sonar-scanner-version >> $GITHUB_OUTPUT
-
+      - name: "Update default version"
+        if: steps.tagged-version.outputs.sonar-scanner-version != steps.latest-version.outputs.sonar-scanner-version
+        shell: bash
+        env:
+          NEW_VERSION: ${{ steps.latest-version.outputs.sonar-scanner-version }}
+        run: |
+           yq -i '.inputs.scannerVersion.default = "${NEW_VERSION}"' action.yml
       - name: "Create Pull Request for version update"
         if: steps.tagged-version.outputs.sonar-scanner-version != steps.latest-version.outputs.sonar-scanner-version
         shell: bash
@@ -44,6 +50,7 @@ jobs:
           git config --global user.email "sonartech@sonarsource.com"
           git checkout -b ${UPDATE_BRANCH}
           git add sonar-scanner-version
+          git add action.yml
           git commit -m "${TITLE}"
           git push --force-with-lease origin ${UPDATE_BRANCH}
           gh pr list

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,8 @@ inputs:
   scannerVersion:
     description: Version of the Sonar Scanner CLI to use
     required: false
-    default: 6.2.1.4610 # to be kept in sync with sonar-scanner-version
+    # to be kept in sync with sonar-scanner-version
+    default: 6.2.1.4610
   scannerBinariesUrl:
     description: URL to download the Sonar Scanner CLI binaries from
     required: false


### PR DESCRIPTION
[SQSCANGHA-82](https://sonarsource.atlassian.net/browse/SQSCANGHA-82)

I realized that the current update script doesn't update the default version in `action.yml`, so this is an attempt to automate it.

Ping @antonio-garcia-sonarsource if you have an opinion on this.

[SQSCANGHA-82]: https://sonarsource.atlassian.net/browse/SQSCANGHA-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ