### PR TITLE
Bump GitHub actions/cache version

### DIFF
--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -303,7 +303,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarQube Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ github.workspace }}/.sonar/cache
           key: ${{ runner.os }}-${{ runner.arch }}-sonar

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         INPUT_PROJECTBASEDIR: ${{ inputs.projectBaseDir }}
     - name: Load Sonar Scanner CLI from cache
       id: sonar-scanner-cli
-      uses: actions/cache@v4
+      uses: actions/cache@v4.2.0
       env:
         # The default value is 60mins. Reaching timeout is treated the same as a cache miss.
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1

--- a/deprecated-c-cpp/action.yml
+++ b/deprecated-c-cpp/action.yml
@@ -71,7 +71,7 @@ runs:
     - name: Cache sonar-scanner installation
       id: cache-sonar-tools
       if: inputs.cache-binaries == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v4.2.0
       env:
         # The default value is 60mins. Reaching timeout is treated the same as a cache miss.
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1


### PR DESCRIPTION
As shown in the image below, the action tried to use version 4.0.2 of the action cache, which is no longer supported and resulted in a failure. Even though the actions/cache was upgraded to v4, sometimes it still uses a version that makes the action raise this error. We were getting the same error on other workflows that used the cache action, and we solved these false positives by bumping the action version to the recommended pinned version from [their docs](https://github.com/actions/cache)
![image](https://github.com/user-attachments/assets/c2b07d14-7c4f-4836-b439-77761e20a9a2)