### PR TITLE
BUILD-8073 Migrate public repositories workflows to large runners

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestClosed_job:
     name: Pull Request Closed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/qa-deprecated-c-cpp.yml
+++ b/.github/workflows/qa-deprecated-c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     name: Action outputs
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest-large, windows-latest-large, macos-latest, macos-13]
         cache: [true, false]
         include:
           - arch: X64

--- a/.github/workflows/qa-install-build-wrapper.yml
+++ b/.github/workflows/qa-install-build-wrapper.yml
@@ -12,7 +12,7 @@ jobs:
     name: Action outputs
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest-large, windows-latest-large, macos-latest, macos-13]
         cache: [true, false]
         include:
           - arch: X64

--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -13,7 +13,7 @@ jobs:
       No inputs
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest-large, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
       'args' input
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest-large, windows-latest-large, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
       'args' input with command injection will fail
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest-large, windows-latest-large, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
       'projectBaseDir' input
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest-large, windows-latest-large, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -100,7 +100,7 @@ jobs:
   scannerVersionTest:
     name: >
       'scannerVersion' input
-    runs-on: ubuntu-latest # assumes default RUNNER_ARCH for linux is X64
+    runs-on: ubuntu-latest-large # assumes default RUNNER_ARCH for linux is X64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -120,7 +120,7 @@ jobs:
   scannerBinariesUrlTest:
     name: >
       'scannerBinariesUrl' input with invalid URL
-    runs-on: ubuntu-latest # assumes default RUNNER_ARCH for linux is X64
+    runs-on: ubuntu-latest-large # assumes default RUNNER_ARCH for linux is X64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -148,7 +148,7 @@ jobs:
   scannerBinariesUrlIsEscapedWithWget:
     name: >
       'scannerBinariesUrl' is escaped with wget so special chars are not injected in the download command
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -169,7 +169,7 @@ jobs:
   scannerBinariesUrlIsEscapedWithCurl:
     name: >
       'scannerBinariesUrl' is escaped with curl so special chars are not injected in the download command
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -198,7 +198,7 @@ jobs:
   dontFailGradleTest:
     name: >
       Don't fail on Gradle project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -219,7 +219,7 @@ jobs:
   dontFailGradleKotlinTest:
     name: >
       Don't fail on Kotlin Gradle project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -240,7 +240,7 @@ jobs:
   dontFailMavenTest:
     name: >
       Don't fail on Maven project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -259,7 +259,7 @@ jobs:
         run: |
           ./test/assertFileExists ./output.properties
   runAnalysisTest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     services:
       sonarqube:
         image: sonarqube:lts-community
@@ -294,7 +294,7 @@ jobs:
       'RUNNER_DEBUG' is used
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest-large, windows-latest-large, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -312,7 +312,7 @@ jobs:
         run: |
           ./test/assertFileContains ./output.properties "sonar.verbose=true"
   runAnalysisWithCacheTest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     services:
       sonarqube:
         image: sonarqube:lts-community
@@ -353,7 +353,7 @@ jobs:
       'SONARCLOUD_URL' is used
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest-large, windows-latest-large, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -372,7 +372,7 @@ jobs:
           ./test/assertFileContains ./output.properties "sonar.scanner.sonarcloudUrl=mirror.sonarcloud.io" 
   dontFailWhenMissingWgetButCurlAvailable:
     name: Don't fail when missing wget but curl available
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -398,7 +398,7 @@ jobs:
           ./test/assertFileExists ./output.properties
   dontFailWhenMissingCurlButWgetAvailable:
     name: Don't fail when missing curl but wget available
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -425,7 +425,7 @@ jobs:
           ./test/assertFileExists ./output.properties
   failWhenBothWgetAndCurlMissing:
     name: Fail when both wget and curl are missing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -458,7 +458,7 @@ jobs:
   curlPerformsRedirect:
     name: >
       curl performs redirect when scannerBinariesUrl returns 3xx
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -492,7 +492,7 @@ jobs:
       'SONAR_ROOT_CERT' is converted to truststore
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest-large, windows-latest-large, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -544,7 +544,7 @@ jobs:
   analysisWithSslCertificate:
     name: >
       Analysis takes into account 'SONAR_ROOT_CERT'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -652,7 +652,7 @@ jobs:
   overridesScannerLocalFolderWhenPresent: # can happen in uncleaned self-hosted runners
     name: >
       'SCANNER_LOCAL_FOLDER' is cleaned with warning when present
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -686,7 +686,7 @@ jobs:
   updateTruststoreWhenPresent: # can happen in uncleaned self-hosted runners
     name: >
       truststore.p12 is updated when present
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -815,7 +815,7 @@ jobs:
   scannerVersionValidationTest:
     name: >
       'scannerVersion' input validation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/qa-scripts.yml
+++ b/.github/workflows/qa-scripts.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create-install-dir-test:
     name: create_install_path.sh
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,7 +107,7 @@ jobs:
           grep "=== Script failed ===" output
   setup-script-test:
     name: configure_paths.sh
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     env:
       INSTALL_PATH: 'install-directory'
       SONAR_HOST_URL: 'http://sonar-host.com'
@@ -250,7 +250,7 @@ jobs:
           grep "=== Script failed ===" output
   download-script-test:
     name: download.sh
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -319,7 +319,7 @@ jobs:
           grep "=== Script failed ===" output
   fetch-latest-version-test:
     name: fetch_latest_version.sh
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       contents: write
 

--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-version:
     name: Check for sonar-scanner version update
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     outputs:
       should_update: ${{ steps.version-check.outputs.should_update }}
       latest_version: ${{ steps.latest-version.outputs.latest }}
@@ -45,7 +45,7 @@ jobs:
   update-version:
     name: Prepare pull request for sonar-scanner version update
     needs: check-version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
[BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073)

Migrates public repository workflows from standard GitHub-hosted runners to **Large Runners**
(`ubuntu-latest` → `ubuntu-latest-large`, etc.).

See [BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073) for details.


[BUILD-8073]: https://sonarsource.atlassian.net/browse/BUILD-8073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ