### PR TITLE
SQSCANGHA-83 Avoid unbound variable error on parameter expansion

### DIFF
--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -11,12 +11,15 @@ jobs:
   noInputsTest:
     name: >
       No inputs
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run action with args
+      - name: Run action without args
         uses: ./
         env:
           SONAR_HOST_URL: http://not_actually_used

--- a/scripts/run-sonar-scanner-cli.sh
+++ b/scripts/run-sonar-scanner-cli.sh
@@ -77,5 +77,5 @@ scanner_args+=("$@")
 
 set -ux
 
-$SCANNER_BIN "${scanner_args[@]}"
+$SCANNER_BIN ${scanner_args[@]+"${scanner_args[@]}"}
 


### PR DESCRIPTION
[SQSCANGHA-83](https://sonarsource.atlassian.net/browse/SQSCANGHA-83)

<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Make sure any code you changed is covered by tests
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team


[SQSCANGHA-83]: https://sonarsource.atlassian.net/browse/SQSCANGHA-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Reproduced the unbound variable error in a dummy shell script on macos, and validated that the fix with the safe parameter expansion avoids it.
Code used in the test script:

`scanner_args=()`
`set -ux`
`echo ${scanner_args[@]+"${scanner_args[@]}"}`