### PR TITLE
SQSCANGHA-97 Use /usr/bin/env for shebang

### DIFF
--- a/scripts/cert.sh
+++ b/scripts/cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -n "${SONAR_ROOT_CERT}" ]]; then
   echo "Adding custom root certificate to java certificate store"

--- a/scripts/configure_paths.sh
+++ b/scripts/configure_paths.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ${ARCH} != "X64" && ! (${ARCH} == "ARM64" && (${OS} == "macOS" || ${OS} == "Linux")) ]]; then
   echo "::error::Architecture '${ARCH}' is unsupported by build-wrapper"

--- a/scripts/create_install_path.sh
+++ b/scripts/create_install_path.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname -- "$0")/utils.sh"
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname -- "$0")/utils.sh"
 

--- a/scripts/fetch_latest_version.sh
+++ b/scripts/fetch_latest_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname -- "$0")/utils.sh"
 

--- a/scripts/install-sonar-scanner-cli.sh
+++ b/scripts/install-sonar-scanner-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/scripts/run-sonar-scanner-cli.sh
+++ b/scripts/run-sonar-scanner-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/scripts/sanity-checks.sh
+++ b/scripts/sanity-checks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 check_status() {
   exit_status=$?

--- a/test/assertFileContains
+++ b/test/assertFileContains
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/test/assertFileDoesntExist
+++ b/test/assertFileDoesntExist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/test/assertFileExists
+++ b/test/assertFileExists
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 


### PR DESCRIPTION
Some platforms such as NixOS, Guix, and even some BSD distributions don't have `/bin/bash` resulting in errors when trying to run via a self-hosted runner:

```
c00da1f7-23a6-4abd-95c0-9d1c3b591c2a.sh: line 1: /var/ci/runner/_actions/sonarsource/sonarqube-scan-action/v5/scripts/sanity-checks.sh: cannot execute: required file not found
```

The solution is to use `/usr/bin/env` which is guaranteed to be available everywhere.

Further reference:

* https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability
* https://github.com/actions/runner/pull/314

<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Make sure any code you changed is covered by tests
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
