### PR TITLE
Fix command injection from consumer of action

### DIFF
--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -74,6 +74,56 @@ jobs:
       - name: Assert the scanner was not called
         run: |
           ./test/assertFileDoesntExist ./output.properties
+  argsInputInjectionTest2:
+    name: >
+      'args' input with command injection will fail 2
+    strategy:
+      matrix:
+        os: [ ubuntu-latest-large, windows-latest-large, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run action with args
+        uses: ./
+        continue-on-error: true
+        with:
+          args: -Dsonar.someArg="some value `echo Injection` with space"
+        env:
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output.properties"}'
+      - name: Fail if action succeeded
+        if: steps.runTest.outcome == 'success'
+        run: exit 1
+      - name: Assert the scanner was not called
+        run: |
+          ./test/assertFileDoesntExist ./output.properties
+  argsInputInjectionTest3:
+    name: >
+      'args' input with command injection will fail 3
+    strategy:
+      matrix:
+        os: [ ubuntu-latest-large, windows-latest-large, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run action with args
+        uses: ./
+        continue-on-error: true
+        with:
+          args: -Dsonar.someArg="some value $(echo Injection) with space"
+        env:
+          SONAR_HOST_URL: http://not_actually_used
+          SONAR_SCANNER_JSON_PARAMS: '{"sonar.scanner.internal.dumpToFile": "./output.properties"}'
+      - name: Fail if action succeeded
+        if: steps.runTest.outcome == 'success'
+        run: exit 1
+      - name: Assert the scanner was not called
+        run: |
+          ./test/assertFileDoesntExist ./output.properties
   projectBaseDirInputTest:
     name: >
       'projectBaseDir' input

--- a/action.yml
+++ b/action.yml
@@ -53,8 +53,7 @@ runs:
     - name: Run SonarScanner
       run: |
         args=(${{ inputs.args }})
-        cmd=(${GITHUB_ACTION_PATH}/scripts/run-sonar-scanner-cli.sh "${args[@]}")
-        "${cmd[@]}"
+        "${GITHUB_ACTION_PATH}/scripts/run-sonar-scanner-cli.sh" "${args[@]}"
       shell: bash
       env:
         INPUT_PROJECTBASEDIR: ${{ inputs.projectBaseDir }}


### PR DESCRIPTION
Arguments sent to the action should never be treated as shell expression.
Lets say that the user provides the following argument containing the branch name and the first line of the commit message:

```
-Dsonar.projectDescription="refs/heads/some_branch: [workflows] Bump `actions/*`"
```

Then, `actions/*` is not a command that should be executed but, rather a random string that should be treated as user input and thus, be carefully forwarded as-is, without performing any shell expansion, to run-sonar-scanner-cli.sh.


I'm not sure how your tests works and I don't know how to test them locally.
I've simply copied `argsInputInjectionTest` and changed the argument to match arguments using `$()` and back-ticks. Feel free to modify this PR in any way you like for submission.