### PR TITLE
pin actions/cache to a full-length commit SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         INPUT_SCANNERVERSION: ${{ inputs.scannerVersion }}
     - name: Load Sonar Scanner CLI from cache
       id: sonar-scanner-cli
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
       env:
         # The default value is 60mins. Reaching timeout is treated the same as a cache miss.
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1


### PR DESCRIPTION
GitHub suggests pinning actions to SHAs (not versions). If you’re using sonarqube-scan-action, it could break if that check ever gets turned on. Reference: As per https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

In general it's recommended to only pin to SHAs and have a dependabot scan update the SHAs for you.
