### PR TITLE
Use commit SHA pinning for action metadata files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         INPUT_SCANNERVERSION: ${{ inputs.scannerVersion }}
     - name: Load Sonar Scanner CLI from cache
       id: sonar-scanner-cli
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       env:
         # The default value is 60mins. Reaching timeout is treated the same as a cache miss.
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1


### PR DESCRIPTION
We're trying to enable GitHub's recent ["enforce SHA pinning" configuration](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning).  
This feature requires all GitHub Action calls—including dependent third-party actions—to be written in the SHA-pinned style.  
Therefore, we are motivated to ensure that every third-party action we depend on is properly version-pinned.

If there are no objections, I’d like to update the unpinned action calls in the action metadata file to use SHA pinning.  
This format is compatible with version updates via Renovate or Dependabot, and can also be updated locally with tools like [pinact](https://github.com/suzuki-shunsuke/pinact).

---

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Make sure any code you changed is covered by tests
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)
