### PR TITLE
SQSCANGHA-129 Fix the Analysis Processing team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/* @sonarsource/orchestration-processing-squad
+.github/* @sonarsource/quality-processing-squad


### PR DESCRIPTION
## Summary
Updates the GitHub team name in CODEOWNERS from `orchestration-processing-squad` to `quality-processing-squad` to reflect the team's move from Code Orchestration to Code Quality.

## Changes
- Updated `.github/CODEOWNERS` to use the new team name `quality-processing-squad`

## Related
- Jira ticket: SC-41026

🤖 Generated with [Claude Code](https://claude.com/claude-code)