### PR TITLE
BUILD-10861 Dependabot 5-day cooldown + internal excludes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,9 @@ updates:
       interval: "daily"
       timezone: "CET"
     open-pull-requests-limit: 100
+    cooldown:
+      default-days: 5
+      exclude:
+        - "SonarSource/*"
     commit-message:
       prefix: "NO-JIRA "


### PR DESCRIPTION
## [BUILD-10861](https://sonarsource.atlassian.net/browse/BUILD-10861)

Adds [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown) so **version-update** PRs wait **5 days** after release. Internal Sonar coordinates are **excluded** from cooldown so they are not delayed.

**Note:** Dependabot **security** updates ignore `cooldown` (documented GitHub behavior).

[BUILD-10861]: https://sonarsource.atlassian.net/browse/BUILD-10861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ