### PR TITLE
SQSCANGHA-133 Upgrade the Node version used in UTs + contribution guide

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/contributing.md
+++ b/contributing.md
@@ -32,7 +32,7 @@ Both the main action and the secondary _install-build-wrapper_ action are [Javas
 
 ### Requirements
 
-Make sure you have node 20 & npm installed. We recommend using [nvm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-version-manager-to-install-nodejs-and-npm) for that.
+Make sure you have node 24 & npm installed. We recommend using [nvm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-version-manager-to-install-nodejs-and-npm) for that.
 
 ### Building & testing
 


### PR DESCRIPTION
Before:

> Found in cache @ /opt/hostedtoolcache/node/20.20.1/x64

After: 

https://github.com/SonarSource/sonarqube-scan-action/actions/runs/23939458193/job/69822398565?pr=226
> Found in cache @ /opt/hostedtoolcache/node/24.14.1/x64