### PR TITLE
Add build and dist/ freshness check to CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,10 +31,6 @@ jobs:
             git status --short
             exit 1
           fi
-            echo "::error::dist/ is out of date. Run 'npm run build' and commit the changes."
-            git diff --name-only
-            exit 1
-          fi
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,11 @@ jobs:
 
       - name: Check dist/ is up-to-date
         run: |
-          if [ -n "$(git diff --name-only)" ]; then
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::dist/ is out of date. Run 'npm run build' and commit the changes."
+            git status --short
+            exit 1
+          fi
             echo "::error::dist/ is out of date. Run 'npm run build' and commit the changes."
             git diff --name-only
             exit 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,5 +21,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
+      - name: Check dist/ is up-to-date
+        run: |
+          if [ -n "$(git diff --name-only)" ]; then
+            echo "::error::dist/ is out of date. Run 'npm run build' and commit the changes."
+            git diff --name-only
+            exit 1
+          fi
+
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Summary
- CI workflow was missing a build step, so dependency updates (e.g. Dependabot bumps to rollup/picomatch) would be merged with `dist/` still compiled from the **previous** toolchain
- This resulted in e.g. `sonarqube-scan-action` 7.1.0 being released with JavaScript compiled using previous dependencies — before the Dependabot dependency changes were merged
- Adds `npm run build` and a `git diff` check to CI so it fails if `dist/` is out of date

## Test plan
- [ ] Verify CI passes on this PR (dist/ should be up-to-date)
- [ ] Test with a simulated dependency bump to confirm CI catches stale dist/

🤖 Generated with [Claude Code](https://claude.com/claude-code)