### PR TITLE
SQSCANGHA-140 Set skipSignatureVerification default value to true to avoid breaking change

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,9 @@ inputs:
     required: false
     default: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli
   skipSignatureVerification:
-    description: Skip GPG signature verification (not recommended for security)
+    description: Skip GPG signature verification (defaults to true temporarily while dirmngr dependency is resolved; set to false to enable verification)
     required: false
-    default: "false"
+    default: "true"
 runs:
   using: node24
   main: dist/index.js


### PR DESCRIPTION
Address https://github.com/SonarSource/sonarqube-scan-action/pull/235#issuecomment-4336781662

On #235, a new feature was introduce to check OpenPGP signature and improve security standards. Even though this is a great feature, it breaks the action execution when `dirmngr` is not present on runner. Shortly after feature was merged, remarks came into PR to point that out. Full error log is below

```
Installing Sonar Scanner CLI 8.0.1.6346 for linux-x64...
Downloading from: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.0.1.6346-linux-x64.zip
Downloading signature from: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.0.1.6346-linux-x64.zip.asc
Importing SonarSource public key from hkps://keyserver.ubuntu.com...
/usr/bin/gpg --homedir /home/runner/_work/_temp/gpg-home-1777397281878-365 --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 679F1EE92B19609DE816FDE81DB198F93525EC1A
gpg: keybox '/home/runner/_work/_temp/gpg-home-1777397281878-365/pubring.kbx' created
gpg: error running '/usr/bin/dirmngr': probably not installed
gpg: failed to start dirmngr '/usr/bin/dirmngr': Configuration error
gpg: can't connect to the dirmngr: Configuration error
gpg: keyserver receive failed: No dirmngr
Warning: Failed to import key from hkps://keyserver.ubuntu.com: The process '/usr/bin/gpg' failed with exit code 2
Attempting fallback keyserver hkps://keys.openpgp.org...
/usr/bin/gpg --homedir /home/runner/_work/_temp/gpg-home-1777397281878-365 --batch --keyserver hkps://keys.openpgp.org --recv-keys 679F1EE92B19609DE816FDE81DB198F93525EC1A
gpg: error running '/usr/bin/dirmngr': probably not installed
gpg: failed to start dirmngr '/usr/bin/dirmngr': Configuration error
gpg: can't connect to the dirmngr: Configuration error
gpg: keyserver receive failed: No dirmngr
Error: Action failed: Failed to import SonarSource public key from all keyservers. Primary (hkps://keyserver.ubuntu.com): The process '/usr/bin/gpg' failed with exit code 2. Fallback (hkps://keys.openpgp.org): The process '/usr/bin/gpg' failed with exit code 2
```

This PR aims to change default value of `skipSignatureVerification` to true, until a proper structural solution is in place within the action flow or Sonar team decides to mark this feature as a breaking change, turning default value to `false` on a `v8` future release.