### PR TITLE
SQSCANGHA-144 Add gate jobs to QA workflows for branch protection

### DIFF
--- a/.github/workflows/qa-deprecated-c-cpp.yml
+++ b/.github/workflows/qa-deprecated-c-cpp.yml
@@ -88,3 +88,17 @@ jobs:
           BINARY: ${{ steps.run-action.outputs.build-wrapper-binary }}
         run: |
           ("$BINARY" || true) | grep "build-wrapper, version "
+
+  qa-gate:
+    name: QA Deprecated C and C++ - gate
+    runs-on: ubuntu-latest
+    needs: [output-test]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All checks passed."

--- a/.github/workflows/qa-install-build-wrapper.yml
+++ b/.github/workflows/qa-install-build-wrapper.yml
@@ -70,3 +70,17 @@ jobs:
           BINARY: ${{ steps.run-action.outputs.build-wrapper-binary }}
         run: |
           ("$BINARY" || true) | grep "build-wrapper, version "
+
+  qa-gate:
+    name: QA Install Build Wrapper - gate
+    runs-on: ubuntu-latest
+    needs: [output-test]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All checks passed."

--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -827,3 +827,40 @@ jobs:
         run: |
           echo "Action with invalid scannerVersion should have failed but succeeded"
           exit 1
+
+  qa-gate:
+    name: QA Main - gate
+    runs-on: ubuntu-latest
+    needs:
+      - noInputsTest
+      - argsInputTest
+      - argsInputInjectionTest
+      - backtickCommandInjectionTest
+      - dollarSymbolCommandInjectionTest
+      - otherCommandInjectionVariantsTest
+      - projectBaseDirInputTest
+      - scannerVersionTest
+      - scannerBinariesUrlTest
+      - scannerBinariesUrlIsEscapedWithWget
+      - scannerBinariesUrlIsEscapedWithCurl
+      - dontFailGradleTest
+      - dontFailGradleKotlinTest
+      - dontFailMavenTest
+      - runAnalysisTest
+      - runnerDebugUsedTest
+      - runAnalysisWithCacheTest
+      - overrideSonarcloudUrlTest
+      - curlPerformsRedirect
+      - useSslCertificate
+      - analysisWithSslCertificate
+      - updateTruststoreWhenPresent
+      - scannerVersionValidationTest
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All checks passed."


### PR DESCRIPTION
## Summary

- Add a non-matrix gate job (`qa-gate`) to `qa-main.yml`, `qa-deprecated-c-cpp.yml`, and `qa-install-build-wrapper.yml`
- Each gate job depends on all other jobs in its workflow via `needs:` and runs with `if: always()`
- The gate job fails if any dependency failed or was cancelled, otherwise succeeds

## Why

`qa-deprecated-c-cpp` and `qa-install-build-wrapper` both use a matrix job named "Action outputs" with the same matrix values — this causes naming collisions in GitHub check contexts, making it impossible to independently require both workflows via branch protection. Gate jobs solve this by providing a single, unique, stable check context per workflow.

This is a prerequisite for SQSCANGHA-144 (configuring branch protection on `master` in re-service-config).

## Test plan

- [ ] Open a test PR and verify that `QA Main - gate`, `QA Deprecated C and C++ - gate`, and `QA Install Build Wrapper - gate` checks appear
- [ ] Verify gate passes when all jobs pass
- [ ] Verify gate fails when a job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)