### PR TITLE
SQSCANGHA-84 Remove outdated wget/curl references

### DIFF
--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -245,9 +245,9 @@ jobs:
       - name: Assert Sonar Scanner CLI was not executed
         run: |
           ./test/assertFileDoesntExist ./output.properties
-  scannerBinariesUrlIsEscapedWithWget:
+  scannerBinariesUrlCommandInjectionTest:
     name: >
-      'scannerBinariesUrl' is escaped with wget so special chars are not injected in the download command
+      'scannerBinariesUrl' does not allow command injection via semicolons
     runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -266,22 +266,14 @@ jobs:
       - name: Assert file.txt does not exist
         run: |
           ./test/assertFileDoesntExist "$RUNNER_TEMP/sonarscanner/file.txt"
-  scannerBinariesUrlIsEscapedWithCurl:
+  scannerBinariesUrlCommandInjectionWithSpacesTest:
     name: >
-      'scannerBinariesUrl' is escaped with curl so special chars are not injected in the download command
+      'scannerBinariesUrl' does not allow command injection via spaces and quotes
     runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove wget
-        run: sudo apt-get remove -y wget
-      - name: Assert wget is not available
-        run: |
-          if command -v wget 2>&1 >/dev/null
-          then
-            exit 1
-          fi
       - name: Run action with scannerBinariesUrl
         id: runTest
         uses: ./
@@ -472,22 +464,14 @@ jobs:
         run: |
           ./test/assertFileContains ./output.properties "sonar.host.url=mirror.sonarcloud.io"
           ./test/assertFileContains ./output.properties "sonar.scanner.sonarcloudUrl=mirror.sonarcloud.io"
-  curlPerformsRedirect:
+  scannerBinariesUrlRedirectFollowed:
     name: >
-      curl performs redirect when scannerBinariesUrl returns 3xx
+      scannerBinariesUrl redirect (3xx) is followed
     runs-on: github-ubuntu-latest-s
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove wget
-        run: sudo apt-get remove -y wget
-      - name: Assert wget is not available
-        run: |
-          if command -v wget 2>&1 >/dev/null
-          then
-            exit 1
-          fi
       - name: Generate SSL certificates for nginx
         run: ./generate-ssl.sh
         working-directory: .github/qa-nginx-redirecting
@@ -841,8 +825,8 @@ jobs:
       - projectBaseDirInputTest
       - scannerVersionTest
       - scannerBinariesUrlTest
-      - scannerBinariesUrlIsEscapedWithWget
-      - scannerBinariesUrlIsEscapedWithCurl
+      - scannerBinariesUrlCommandInjectionTest
+      - scannerBinariesUrlCommandInjectionWithSpacesTest
       - dontFailGradleTest
       - dontFailGradleKotlinTest
       - dontFailMavenTest
@@ -850,7 +834,7 @@ jobs:
       - runnerDebugUsedTest
       - runAnalysisWithCacheTest
       - overrideSonarcloudUrlTest
-      - curlPerformsRedirect
+      - scannerBinariesUrlRedirectFollowed
       - useSslCertificate
       - analysisWithSslCertificate
       - updateTruststoreWhenPresent

--- a/README.md
+++ b/README.md
@@ -483,10 +483,10 @@ See also [example configurations of C++ projects for SonarQube Server](https://g
 
 When running the action in a self-hosted runner or container, please ensure that the following programs are installed:
 
-* **curl** or **wget**
-* **unzip**
 * **gpg**
 * **dirmngr**
+
+Note: `gpg` and `dirmngr` are only required for GPG signature verification (enabled by default). They can be omitted when setting `skipSignatureVerification: true`.
 
 ### Additional information
 


### PR DESCRIPTION
## Summary

- Ticket [SQSCANGHA-84](https://sonarsource.atlassian.net/browse/SQSCANGHA-84): `wget --no-verbose` failing on Busybox — the original bug no longer exists since the action was refactored to use Node.js (`@actions/tool-cache`) for downloads, which doesn't use `wget` or `curl` at all
- Remove `curl`/`wget` and `unzip` from the self-hosted runner prerequisites in the README (not needed by the Node.js action); add a note that `gpg`/`dirmngr` can be skipped with `skipSignatureVerification: true`
- Rename three QA test jobs that had misleading wget/curl-specific names — they test URL injection prevention and redirect handling, which are mechanism-agnostic

## Test plan

- [ ] QA gate passes with the renamed job IDs
- [ ] README prerequisites section is accurate for self-hosted runner users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SQSCANGHA-84]: https://sonarsource.atlassian.net/browse/SQSCANGHA-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ