### PR TITLE
docs: use YAML literal block `|` for args examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ In case you need to add additional analysis parameters, and you do not wish to s
 - uses: SonarSource/sonarqube-scan-action@<action version>
   with:
     projectBaseDir: app/src
-    args: >
+    args: |
       -Dsonar.organization=my-organization # For SonarQube Cloud only
-      "-Dsonar.projectName=My Project"
+      -Dsonar.projectName=My Project
       -Dsonar.projectKey=my-projectkey
       -Dsonar.python.coverage.reportPaths=coverage.xml
       -Dsonar.sources=lib/
@@ -164,7 +164,8 @@ In case you need to add additional analysis parameters, and you do not wish to s
 > In version 6, the way the `args` option is handled has been changed to prevent command injection.
 > As a result, we no longer support the full bash syntax.
 > This means there is now a much more restricted use of quoting and escaping compared to older versions of the action.
-> Example:
+> Using the literal block scalar (|) is considered best practice.
+> However, if you prefer to use the folded block scalar (>), you must wrap individual arguments containing spaces or special characters in quotes like so:
 > ```yaml
 > with:
 >   args: >
@@ -357,7 +358,7 @@ jobs:
         SONAR_ROOT_CERT: ${{ secrets.SONAR_ROOT_CERT }}
       with:
         # Consult https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/ for more information and options
-        args: >
+        args: |
           --define "sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" 
 ```
 
@@ -461,7 +462,7 @@ jobs:
         SONAR_ROOT_CERT: ${{ secrets.SONAR_ROOT_CERT }}
       with:
         # Consult https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/ for more information and options
-        args: >
+        args: |
           --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" 
 ```
 


### PR DESCRIPTION
# Overview: Update multi-line args examples to use YAML literal block scalar (|)

## Description:
Following a bug we saw with ">" i found the docs on the v5/v6 architectural rewrite from Bash to JavaScript
(v6 Breaking Change)[https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v6.0.0]

Now that the args input is handled by the secure argument tokenizer in Node.js rather than being evaluated in bash i believe the ">" as recommended usage is outdated

### Problem: 
The current README.md documentation repeatedly uses YAML folded block scalar (>) for multi-line configurations. The > operator strips newlines and replaces them with spaces. This forces the underlying JavaScript parser to tokenize a single folded string, introducing brittle edge cases with trailing whitespace, hidden line endings (the bug we had), where the current documented advice is to ask users to quote individual parameters (as noted in the v6 release notes) to prevent malformed argument splitting.

### Solution: 
This PR updates the primary examples and notes to use the YAML literal block scalar (|). This preserves literal newlines, passing each parameter cleanly to the runner on its own line. This fixed our bug much more cleanly and i'm not sure why it wouldnt be the recommended approach now that you are using JS over Bash. This would remove unnecessary tokenization friction, eliminates unintended argument-folding bugs, and removes the maintenance burden for users of wrapping every standard argument in quotes.

## Changes:
- Updated the main args example under the Configuration section to use |.
- Clarified the [!NOTE] block to highlight | as the modern best practice while preserving the historical context and quoting workarounds required for the > operator.
- Standardized trailing examples in the Workflow Examples sections to maintain documentation consistency.